### PR TITLE
running into an issue where kubeval cannot evaluate some manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.0.1
+
+## Changes
+
+* Kubeval does not currently evaluate ```cloud.google.com``` schemas. This causes non K8s native manifests to fail deployment. Added some ignore logic to check manifests for ```apiVersion: cloud.google.com``` and not run kubeval on those files.
+
 # Version 3.0.0
 
 ## Backwards Incompatible Changes

--- a/deploy
+++ b/deploy
@@ -101,12 +101,17 @@ if [ -d "$CI_PROJECT_DIR/kubernetes" ]; then
 
   echo "Evaluating rendered manifests."
   # Dump the templated manifests to the log for easier debugging and run kubeval against each
-  for filename in /tmp/kubernetes/*.yaml; do
-    echo "Running kubeval against $filename"
-    echo
-    cat "$filename"
-    echo
-    kubeval $filename 
+  for filename in kubernetes/*.yaml; do
+    echo "Checking for non-K8s native manifests"
+    if grep -q 'apiVersion: cloud.google.com' $filename; then
+        echo "Found non-native K8s manifest - skipping - $filename"
+    else
+        echo "Running kubeval against $filename"
+        echo
+        cat "$filename"
+        echo
+        kubeval $filename 
+    fi
   done
   echo "Evaluation finished."
   echo


### PR DESCRIPTION
In particular CRD from the GCE ingress controller to add google CDN support (BackendConfig). Putting a workaround in for now to skip any manifests from cloud.google.com api

see [BackendConfig](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig)
 for reference 