### PR TITLE
Fix: only substitute env var

### DIFF
--- a/deploy
+++ b/deploy
@@ -97,7 +97,7 @@ if [ -d "$CI_PROJECT_DIR/kubernetes" ]; then
         echo "Found a tab in $filename. Tabs are not allowed in manifests. Quitting."
         exit 1
     fi
-    envsubst < $filename > /tmp/kubernetes/$basefile
+    envsubst "`env | awk -F = '{printf \" \$%s\", \$1}'`" < $filename > /tmp/kubernetes/$basefile    
     while grep "{{SECRETS}}" /tmp/kubernetes/$basefile | grep -v "#"; do
       grep -n "{{SECRETS}}" /tmp/kubernetes/$basefile | grep -v "#" | head -n1 | while read -r line ; do
         lineno=$(echo $line | cut -d':' -f1)


### PR DESCRIPTION
The `envsubst` was substituting all variables beginning with a `$`. This was breaking my `ingress.yaml` which is using Nginx variables 

```
nginx.ingress.kubernetes.io/auth-signin: $OAUTH_PROXY_HOST/oauth2/start?rd=$scheme://$host$request_uri
```

With this fix, only existing ENV variables will be replaced by the `envsubst`

Credits: https://github.com/docker-library/docs/issues/496#issuecomment-370452557